### PR TITLE
Issue #7: Add new co-maintainer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ complete text.
 Current Maintainers
 -------------------
 
-- Wilmoth Andy Shillingford (https://github.com/docwilmot)
-- (seeking additional maintainers)
+- [Wilmoth Andy Shillingford](https://github.com/docwilmot)
+- [Robert J. Lang](https://github.com/bugfolder)
 
 Credits
 -------


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ban_ip/issues/7.